### PR TITLE
Changed autogenerated nonce to subsequent + changed tests

### DIFF
--- a/contracts/contracts/Multisig.cairo
+++ b/contracts/contracts/Multisig.cairo
@@ -200,6 +200,17 @@ func require_valid_confirmations_required{
     return ()
 end
 
+func require_valid_tx_index{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    tx_index : felt
+):
+    let (current_tx_index) = _next_tx_index.read()
+    with_attr error_message("invalid tx index"):
+        assert tx_index = current_tx_index
+    end
+
+    return ()
+end
+
 #
 # Getters
 #
@@ -338,12 +349,11 @@ end
 
 @external
 func submit_transaction{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    to : felt, function_selector : felt, calldata_len : felt, calldata : felt*
-) -> (tx_index : felt):
+    to : felt, function_selector : felt, calldata_len : felt, calldata : felt*, tx_index : felt
+):
     alloc_locals
     require_owner()
-
-    let (tx_index) = _next_tx_index.read()
+    require_valid_tx_index(tx_index)
 
     # Store the tx descriptor
     _transactions.write(tx_index=tx_index, field=Transaction.to, value=to)
@@ -362,7 +372,7 @@ func submit_transaction{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_
     SubmitTransaction.emit(owner=caller, tx_index=tx_index, to=to)
     _next_tx_index.write(value=tx_index + 1)
 
-    return (tx_index)
+    return ()
 end
 
 @external

--- a/contracts/contracts/Multisig.cairo
+++ b/contracts/contracts/Multisig.cairo
@@ -203,9 +203,9 @@ end
 func require_valid_tx_index{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     tx_index : felt
 ):
-    let (current_tx_index) = _next_tx_index.read()
+    let (next_tx_index) = _next_tx_index.read()
     with_attr error_message("invalid tx index"):
-        assert tx_index = current_tx_index
+        assert tx_index = next_tx_index
     end
 
     return ()

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -19,7 +19,7 @@ const config: HardhatUserConfig = {
   },
   networks: {
     devnet: {
-      url: "http://127.0.0.1:5050/",
+      url: 'http://127.0.0.1:5050/',
     },
   },
 };

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -19,7 +19,7 @@ const config: HardhatUserConfig = {
   },
   networks: {
     devnet: {
-      url: 'http://127.0.0.1:5050/',
+      url: "http://127.0.0.1:5050/",
     },
   },
 };

--- a/contracts/test/Multisig.test.ts
+++ b/contracts/test/Multisig.test.ts
@@ -49,8 +49,7 @@ describe("Multisig with single owner", function () {
 
   describe(" - submit - ", function () {
     it("transaction submit works", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
 
       const selector = number.toBN(getSelectorFromName("set_balance"));
       const target = number.toBN(targetContract.address);
@@ -58,7 +57,7 @@ describe("Multisig with single owner", function () {
         to: target,
         function_selector: selector,
         calldata: [5],
-        tx_index: txIndex
+        tx_index: txIndex,
       };
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -76,8 +75,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction execute works", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
 
       const payload = defaultPayload(targetContract.address, 6, txIndex);
       await account.invoke(multisig, "submit_transaction", payload);
@@ -93,8 +91,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction execute works for subsequent transactions", async function () {
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      let txIndex = Number((await multisig.call("get_transactions_len")).res);
 
       let payload = defaultPayload(targetContract.address, 7, txIndex);
       await account.invoke(multisig, "submit_transaction", payload);
@@ -123,8 +120,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction with complex arguments work", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
 
       const selector = number.toBN(getSelectorFromName("complex_inputs"));
       const target = number.toBN(targetContract.address);
@@ -149,7 +145,7 @@ describe("Multisig with single owner", function () {
         to: target,
         function_selector: selector,
         calldata: calldata,
-        tx_index: txIndex
+        tx_index: txIndex,
       };
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -170,8 +166,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction execute fails if no confirmations", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 9, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -186,8 +181,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("non-owner can't submit a transaction", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       try {
@@ -201,8 +195,7 @@ describe("Multisig with single owner", function () {
 
   describe("- confirmation - ", function () {
     it("non-owner can't confirm a transaction", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 15, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -228,8 +221,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't confirm an executed transaction", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 16, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -251,8 +243,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't reconfirm a transaction", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -273,8 +264,7 @@ describe("Multisig with single owner", function () {
 
   describe("- revocation -", function () {
     it("non-owner can't revoke a confirmation", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -304,8 +294,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't revoke a confirmation for an executed transaction", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -328,8 +317,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't re-revoke an already revoked transaction confirmation", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -354,8 +342,7 @@ describe("Multisig with single owner", function () {
 
   describe("- execution -", function () {
     it("non-owner can't execute a transaction", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -380,8 +367,7 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't re-execute a transaction", async function () {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       await account.invoke(multisig, "submit_transaction", payload);
@@ -441,8 +427,7 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction execute works", async function () {
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
+    const txIndex = Number((await multisig.call("get_transactions_len")).res);
     const payload = defaultPayload(targetContract.address, 20, txIndex);
 
     await account1.invoke(multisig, "submit_transaction", payload);
@@ -462,8 +447,7 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction execute works with too many confirmations", async function () {
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
+    const txIndex = Number((await multisig.call("get_transactions_len")).res);
     const payload = defaultPayload(targetContract.address, 21, txIndex);
 
     await account1.invoke(multisig, "submit_transaction", payload);
@@ -485,8 +469,7 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction execute works if superfluous confirmer revokes confirmation", async function () {
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
+    const txIndex = Number((await multisig.call("get_transactions_len")).res);
     const payload = defaultPayload(targetContract.address, 22, txIndex);
 
     await account1.invoke(multisig, "submit_transaction", payload);
@@ -511,8 +494,7 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction fails if too many revoke confirmation", async function () {
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
+    const txIndex = Number((await multisig.call("get_transactions_len")).res);
     const payload = defaultPayload(targetContract.address, 23, txIndex);
 
     await account1.invoke(multisig, "submit_transaction", payload);
@@ -544,8 +526,7 @@ describe("Multisig with multiple owners", function () {
 
   // Tests below are interdependent and shall be run sequentially
   it("transaction sets new owners", async function () {
-	const txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
+    const txIndex = Number((await multisig.call("get_transactions_len")).res);
 
     const selector = getSelectorFromName("set_owners");
     const newOwners = [
@@ -556,8 +537,8 @@ describe("Multisig with multiple owners", function () {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [newOwners.length, ...newOwners],
-      tx_index: txIndex
-    }
+      tx_index: txIndex,
+    };
 
     await account1.invoke(multisig, "submit_transaction", payload);
 
@@ -580,17 +561,16 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("set single owner thus lowering required confirmations", async function () {
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
+    const txIndex = Number((await multisig.call("get_transactions_len")).res);
 
-    const selector = getSelectorFromName('set_owners');
+    const selector = getSelectorFromName("set_owners");
     const newOwners = [number.toBN(account2.starknetContract.address)];
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [newOwners.length, ...newOwners],
-      tx_index: txIndex
-    }
+      tx_index: txIndex,
+    };
 
     await account2.invoke(multisig, "submit_transaction", payload);
 
@@ -615,26 +595,32 @@ describe("Multisig with multiple owners", function () {
   it("invalidate previous transactions with set owners", async function () {
     const numTxToSpawn = 5;
     for (let i = 0; i < numTxToSpawn; i++) {
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res);
+      const txIndex = Number((await multisig.call("get_transactions_len")).res);
       const payload = defaultPayload(targetContract.address, 101 + i, txIndex);
-      await account2.invoke(multisig, 'submit_transaction', payload);
+      await account2.invoke(multisig, "submit_transaction", payload);
     }
 
     // Executed set_owners invalidates previous transactions
-    const invalidatingTxIndex =
-      Number((await multisig.call("get_transactions_len")).res);
-    const selector = getSelectorFromName('set_owners_and_confirmations_required');
-    const newOwners = [number.toBN(account2.starknetContract.address), number.toBN(account1.starknetContract.address)];
+    const invalidatingTxIndex = Number(
+      (await multisig.call("get_transactions_len")).res
+    );
+    const selector = getSelectorFromName(
+      "set_owners_and_confirmations_required"
+    );
+    const newOwners = [
+      number.toBN(account2.starknetContract.address),
+      number.toBN(account1.starknetContract.address),
+    ];
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [
-        newOwners.length, ...newOwners, // owners
-        2 // confirmations_required
+        newOwners.length,
+        ...newOwners, // owners
+        2, // confirmations_required
       ],
-      tx_index: invalidatingTxIndex
-    }
+      tx_index: invalidatingTxIndex,
+    };
 
     await account2.invoke(multisig, "submit_transaction", payload);
     await account2.invoke(multisig, "confirm_transaction", {
@@ -672,19 +658,24 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("set invalid number of confirmations", async function () {
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
-    const selector = getSelectorFromName('set_owners_and_confirmations_required');
-    const newOwners = [number.toBN(account2.starknetContract.address), number.toBN(account3.starknetContract.address)];
+    const txIndex = Number((await multisig.call("get_transactions_len")).res);
+    const selector = getSelectorFromName(
+      "set_owners_and_confirmations_required"
+    );
+    const newOwners = [
+      number.toBN(account2.starknetContract.address),
+      number.toBN(account3.starknetContract.address),
+    ];
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [
-        newOwners.length, ...newOwners, // new owners
-        3 // confirmations required
+        newOwners.length,
+        ...newOwners, // new owners
+        3, // confirmations required
       ],
-      tx_index: txIndex
-    }
+      tx_index: txIndex,
+    };
 
     await account2.invoke(multisig, "submit_transaction", payload);
 
@@ -752,18 +743,17 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("set 0 owners", async () => {
-    let txIndex =
-      Number((await multisig.call("get_transactions_len")).res);
+    let txIndex = Number((await multisig.call("get_transactions_len")).res);
     const numOfOwners = 0;
     const selector = getSelectorFromName("set_owners");
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [numOfOwners],
-      tx_index: txIndex
-    }
+      tx_index: txIndex,
+    };
 
-    await account2.invoke(multisig, 'submit_transaction', payload);
+    await account2.invoke(multisig, "submit_transaction", payload);
 
     await account2.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
@@ -779,8 +769,12 @@ describe("Multisig with multiple owners", function () {
 
     // No one shall be able to submit new transactions anymore
     try {
-      const payload = defaultPayload(targetContract.address, txIndex * 2, ++txIndex);
-      await account2.invoke(multisig, 'submit_transaction', payload);
+      const payload = defaultPayload(
+        targetContract.address,
+        txIndex * 2,
+        ++txIndex
+      );
+      await account2.invoke(multisig, "submit_transaction", payload);
     } catch (err: any) {
       assertErrorMsg(err.message, "not owner");
     }

--- a/contracts/test/Multisig.test.ts
+++ b/contracts/test/Multisig.test.ts
@@ -49,18 +49,19 @@ describe("Multisig with single owner", function () {
 
   describe(" - submit - ", function () {
     it("transaction submit works", async function () {
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+
       const selector = number.toBN(getSelectorFromName("set_balance"));
       const target = number.toBN(targetContract.address);
       const payload = {
         to: target,
         function_selector: selector,
         calldata: [5],
+        tx_index: txIndex
       };
+
       await account.invoke(multisig, "submit_transaction", payload);
-
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
-
       const res = await multisig.call("get_transaction", {
         tx_index: txIndex,
       });
@@ -75,10 +76,11 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction execute works", async function () {
-      const payload = defaultPayload(targetContract.address, 6);
-      await account.invoke(multisig, "submit_transaction", payload);
       const txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
+        Number((await multisig.call("get_transactions_len")).res);
+
+      const payload = defaultPayload(targetContract.address, 6, txIndex);
+      await account.invoke(multisig, "submit_transaction", payload);
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -91,10 +93,12 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction execute works for subsequent transactions", async function () {
-      let payload = defaultPayload(targetContract.address, 7);
-      await account.invoke(multisig, "submit_transaction", payload);
       let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
+        Number((await multisig.call("get_transactions_len")).res);
+
+      let payload = defaultPayload(targetContract.address, 7, txIndex);
+      await account.invoke(multisig, "submit_transaction", payload);
+
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -103,9 +107,10 @@ describe("Multisig with single owner", function () {
       });
 
       // submit another transaction with the same multisig
-      payload = defaultPayload(targetContract.address, 8);
+      txIndex = Number((await multisig.call("get_transactions_len")).res);
+      payload = defaultPayload(targetContract.address, 8, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      txIndex = Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -118,6 +123,9 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction with complex arguments work", async function () {
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+
       const selector = number.toBN(getSelectorFromName("complex_inputs"));
       const target = number.toBN(targetContract.address);
       const simpleArray = [1, 2, 3];
@@ -141,11 +149,10 @@ describe("Multisig with single owner", function () {
         to: target,
         function_selector: selector,
         calldata: calldata,
+        tx_index: txIndex
       };
 
       await account.invoke(multisig, "submit_transaction", payload);
-      const txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -163,10 +170,11 @@ describe("Multisig with single owner", function () {
     });
 
     it("transaction execute fails if no confirmations", async function () {
-      const payload = defaultPayload(targetContract.address, 9);
-      await account.invoke(multisig, "submit_transaction", payload);
       const txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 9, txIndex);
+
+      await account.invoke(multisig, "submit_transaction", payload);
       try {
         await account.invoke(multisig, "execute_transaction", {
           tx_index: txIndex,
@@ -178,7 +186,9 @@ describe("Multisig with single owner", function () {
     });
 
     it("non-owner can't submit a transaction", async function () {
-      const payload = defaultPayload(targetContract.address, 10);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 10, txIndex);
 
       try {
         await nonOwner.invoke(multisig, "submit_transaction", payload);
@@ -191,10 +201,11 @@ describe("Multisig with single owner", function () {
 
   describe("- confirmation - ", function () {
     it("non-owner can't confirm a transaction", async function () {
-      const payload = defaultPayload(targetContract.address, 15);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 15, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       try {
         await nonOwner.invoke(multisig, "confirm_transaction", {
           tx_index: txIndex,
@@ -217,14 +228,14 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't confirm an executed transaction", async function () {
-      const payload = defaultPayload(targetContract.address, 16);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 16, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
-
       await account.invoke(multisig, "execute_transaction", {
         tx_index: txIndex,
       });
@@ -240,10 +251,11 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't reconfirm a transaction", async function () {
-      const payload = defaultPayload(targetContract.address, 10);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 10, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -261,10 +273,11 @@ describe("Multisig with single owner", function () {
 
   describe("- revocation -", function () {
     it("non-owner can't revoke a confirmation", async function () {
-      const payload = defaultPayload(targetContract.address, 10);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 10, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -291,10 +304,11 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't revoke a confirmation for an executed transaction", async function () {
-      const payload = defaultPayload(targetContract.address, 10);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 10, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -314,10 +328,11 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't re-revoke an already revoked transaction confirmation", async function () {
-      const payload = defaultPayload(targetContract.address, 10);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 10, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -339,10 +354,11 @@ describe("Multisig with single owner", function () {
 
   describe("- execution -", function () {
     it("non-owner can't execute a transaction", async function () {
-      const payload = defaultPayload(targetContract.address, 10);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 10, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -364,10 +380,11 @@ describe("Multisig with single owner", function () {
     });
 
     it("can't re-execute a transaction", async function () {
-      const payload = defaultPayload(targetContract.address, 10);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 10, txIndex);
+
       await account.invoke(multisig, "submit_transaction", payload);
-      let txIndex =
-        Number((await multisig.call("get_transactions_len")).res) - 1;
       await account.invoke(multisig, "confirm_transaction", {
         tx_index: txIndex,
       });
@@ -424,15 +441,18 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction execute works", async function () {
-    const payload = defaultPayload(targetContract.address, 20);
+    const txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+    const payload = defaultPayload(targetContract.address, 20, txIndex);
+
     await account1.invoke(multisig, "submit_transaction", payload);
-    let txIndex = Number((await multisig.call("get_transactions_len")).res) - 1;
     await account1.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
     });
     await account2.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
     });
+
     await account1.invoke(multisig, "execute_transaction", {
       tx_index: txIndex,
     });
@@ -442,9 +462,11 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction execute works with too many confirmations", async function () {
-    const payload = defaultPayload(targetContract.address, 21);
+    const txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+    const payload = defaultPayload(targetContract.address, 21, txIndex);
+
     await account1.invoke(multisig, "submit_transaction", payload);
-    let txIndex = Number((await multisig.call("get_transactions_len")).res) - 1;
     await account1.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
     });
@@ -463,9 +485,11 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction execute works if superfluous confirmer revokes confirmation", async function () {
-    const payload = defaultPayload(targetContract.address, 22);
+    const txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+    const payload = defaultPayload(targetContract.address, 22, txIndex);
+
     await account1.invoke(multisig, "submit_transaction", payload);
-    let txIndex = Number((await multisig.call("get_transactions_len")).res) - 1;
     await account1.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
     });
@@ -487,9 +511,11 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("transaction fails if too many revoke confirmation", async function () {
-    const payload = defaultPayload(targetContract.address, 23);
+    const txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+    const payload = defaultPayload(targetContract.address, 23, txIndex);
+
     await account1.invoke(multisig, "submit_transaction", payload);
-    let txIndex = Number((await multisig.call("get_transactions_len")).res) - 1;
     await account1.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
     });
@@ -518,6 +544,9 @@ describe("Multisig with multiple owners", function () {
 
   // Tests below are interdependent and shall be run sequentially
   it("transaction sets new owners", async function () {
+	const txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+
     const selector = getSelectorFromName("set_owners");
     const newOwners = [
       number.toBN(account2.starknetContract.address),
@@ -527,11 +556,10 @@ describe("Multisig with multiple owners", function () {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [newOwners.length, ...newOwners],
-    };
+      tx_index: txIndex
+    }
 
     await account1.invoke(multisig, "submit_transaction", payload);
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res) - 1;
 
     await account1.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
@@ -552,17 +580,19 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("set single owner thus lowering required confirmations", async function () {
-    const selector = getSelectorFromName("set_owners");
+    const txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+
+    const selector = getSelectorFromName('set_owners');
     const newOwners = [number.toBN(account2.starknetContract.address)];
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [newOwners.length, ...newOwners],
-    };
+      tx_index: txIndex
+    }
 
     await account2.invoke(multisig, "submit_transaction", payload);
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res) - 1;
 
     await account2.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
@@ -585,32 +615,28 @@ describe("Multisig with multiple owners", function () {
   it("invalidate previous transactions with set owners", async function () {
     const numTxToSpawn = 5;
     for (let i = 0; i < numTxToSpawn; i++) {
-      const payload = defaultPayload(targetContract.address, 101 + i);
-      await account2.invoke(multisig, "submit_transaction", payload);
+      const txIndex =
+        Number((await multisig.call("get_transactions_len")).res);
+      const payload = defaultPayload(targetContract.address, 101 + i, txIndex);
+      await account2.invoke(multisig, 'submit_transaction', payload);
     }
 
     // Executed set_owners invalidates previous transactions
-    const selector = getSelectorFromName(
-      "set_owners_and_confirmations_required"
-    );
-    const newOwners = [
-      number.toBN(account2.starknetContract.address),
-      number.toBN(account1.starknetContract.address),
-    ];
+    const invalidatingTxIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+    const selector = getSelectorFromName('set_owners_and_confirmations_required');
+    const newOwners = [number.toBN(account2.starknetContract.address), number.toBN(account1.starknetContract.address)];
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [
-        newOwners.length,
-        ...newOwners, // owners
-        2, // confirmations_required
+        newOwners.length, ...newOwners, // owners
+        2 // confirmations_required
       ],
-    };
+      tx_index: invalidatingTxIndex
+    }
 
     await account2.invoke(multisig, "submit_transaction", payload);
-    const invalidatingTxIndex =
-      Number((await multisig.call("get_transactions_len")).res) - 1;
-
     await account2.invoke(multisig, "confirm_transaction", {
       tx_index: invalidatingTxIndex,
     });
@@ -646,26 +672,21 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("set invalid number of confirmations", async function () {
-    const selector = getSelectorFromName(
-      "set_owners_and_confirmations_required"
-    );
-    const newOwners = [
-      number.toBN(account2.starknetContract.address),
-      number.toBN(account3.starknetContract.address),
-    ];
+    const txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
+    const selector = getSelectorFromName('set_owners_and_confirmations_required');
+    const newOwners = [number.toBN(account2.starknetContract.address), number.toBN(account3.starknetContract.address)];
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [
-        newOwners.length,
-        ...newOwners, // new owners
-        3, // confirmations required
+        newOwners.length, ...newOwners, // new owners
+        3 // confirmations required
       ],
-    };
+      tx_index: txIndex
+    }
 
     await account2.invoke(multisig, "submit_transaction", payload);
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res) - 1;
 
     await account1.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
@@ -731,17 +752,18 @@ describe("Multisig with multiple owners", function () {
   });
 
   it("set 0 owners", async () => {
+    let txIndex =
+      Number((await multisig.call("get_transactions_len")).res);
     const numOfOwners = 0;
     const selector = getSelectorFromName("set_owners");
     const payload = {
       to: number.toBN(multisig.address),
       function_selector: number.toBN(selector),
       calldata: [numOfOwners],
-    };
+      tx_index: txIndex
+    }
 
-    await account2.invoke(multisig, "submit_transaction", payload);
-    const txIndex =
-      Number((await multisig.call("get_transactions_len")).res) - 1;
+    await account2.invoke(multisig, 'submit_transaction', payload);
 
     await account2.invoke(multisig, "confirm_transaction", {
       tx_index: txIndex,
@@ -757,8 +779,8 @@ describe("Multisig with multiple owners", function () {
 
     // No one shall be able to submit new transactions anymore
     try {
-      const payload = defaultPayload(targetContract.address, txIndex * 2);
-      await account2.invoke(multisig, "submit_transaction", payload);
+      const payload = defaultPayload(targetContract.address, txIndex * 2, ++txIndex);
+      await account2.invoke(multisig, 'submit_transaction', payload);
     } catch (err: any) {
       assertErrorMsg(err.message, "not owner");
     }

--- a/contracts/test/utils.ts
+++ b/contracts/test/utils.ts
@@ -3,14 +3,20 @@ import { number } from "starknet";
 import { getSelectorFromName } from "starknet/dist/utils/hash";
 import { BigNumber, utils } from "ethers";
 
-export const defaultPayload = (contractAddress: string, newValue: number) => {
+export const defaultPayload = (
+  contractAddress: string,
+  newValue: number,
+  txIndex: number
+) => {
   const setSelector = number.toBN(getSelectorFromName("set_balance"));
   const target = number.toBN(contractAddress);
   const setPayload = {
     to: target,
     function_selector: setSelector,
     calldata: [newValue],
+    tx_index: txIndex,
   };
+
   return setPayload;
 };
 


### PR DESCRIPTION
Applied changes discussed in [this issue](https://github.com/eqlabs/starknet-multisig/issues/15). 
Contract now checks the previously submitted nonce and makes sure this newest nonce is previous + 1.